### PR TITLE
futures: make the exchange a direct param of basic_publish

### DIFF
--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -13,17 +13,17 @@ build = "build.rs"
 
 [dependencies]
 log = "^0.3"
-nom = "^2.2"
+nom = "^3.0"
 cookie-factory = "^0.2"
-amq-protocol = "^0.16"
-clippy = {version = "^0.0.131", optional = true}
+amq-protocol = "^0.18"
+clippy = {version = "^0.0.135", optional = true}
 
 [dependencies.sasl]
 version= "^0.4"
 default-features = false
 
 [build-dependencies]
-amq-protocol = "^0.16"
+amq-protocol = "^0.18"
 
 [dev-dependencies]
 env_logger = "^0.4"

--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["database"]
 license = "MIT"
 
 [dependencies]
-nom = "^2.2"
+nom = "^3.0"
 log = "^0.3"
 bytes = "^0.4"
 futures = "^0.1"
@@ -19,13 +19,13 @@ tokio-io = "^0.1"
 tokio-timer = "^0.1"
 lapin-async = {version = "^0.8", path = "../async"}
 cookie-factory = "^0.2"
-amq-protocol = "^0.16"
+amq-protocol = "^0.18"
 
 [dev-dependencies]
-nom = "^2.2"
+nom = "^3.0"
 env_logger = "^0.4"
 futures = "^0.1"
-rustls = "^0.7"
+rustls = "^0.8"
 tokio-core = "^0.1"
 tokio-rustls = "^0.2"
 webpki-roots = "^0.10"

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -35,12 +35,10 @@ fn main() {
           channel.exchange_declare("hello_exchange", "direct", &ExchangeDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
             channel.queue_bind("hello", "hello_exchange", "hello_2", &QueueBindOptions::default(), FieldTable::new()).and_then(move |_| {
               channel.basic_publish(
+                "hello_exchange",
                 "hello_2",
                 b"hello from tokio",
-                &BasicPublishOptions {
-                  exchange: "hello_exchange".to_string(),
-                  ..Default::default()
-                },
+                &BasicPublishOptions::default(),
                 BasicProperties::default().with_user_id("guest".to_string()).with_reply_to("foobar".to_string())
               ).map(|confirmation| {
                 info!("publish got confirmation: {:?}", confirmation)

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -59,7 +59,7 @@
 //!       channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
 //!         info!("channel {} declared queue {}", id, "hello");
 //!
-//!         channel.basic_publish("hello", b"hello from tokio", &BasicPublishOptions::default(), BasicProperties::default())
+//!         channel.basic_publish("", "hello", b"hello from tokio", &BasicPublishOptions::default(), BasicProperties::default())
 //!       })
 //!     })
 //!   ).unwrap();

--- a/futures/tests/connection.rs
+++ b/futures/tests/connection.rs
@@ -35,7 +35,7 @@ fn connection() {
           info!("channel {} declared queue {}", id, "hello");
 
           channel.queue_purge("hello").and_then(move |_| {
-            channel.basic_publish("hello", b"hello from tokio", &BasicPublishOptions::default(), BasicProperties::default())
+            channel.basic_publish("", "hello", b"hello from tokio", &BasicPublishOptions::default(), BasicProperties::default())
           })
         })
       }).and_then(move |_| {


### PR DESCRIPTION
It doesn't make sense to have it in BasicPublishOptions as it's one of the most important parameters.
This makes the API comprehension more straightforward wrt other libs.

Fixes #49 
Based on #48 to fix example/tls.rs build