### PR TITLE
async: don't reply to heartbeat frames

### DIFF
--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -379,7 +379,7 @@ impl Connection {
         }
       },
       Frame::Heartbeat(_) => {
-        self.frame_queue.push_back(Frame::Heartbeat(0));
+        debug!("received heartbeat from server");
       },
       Frame::Header(channel_id, _, header) => {
         self.handle_content_header_frame(channel_id, header.body_size, header.properties);


### PR DESCRIPTION
We're supposed to send heartbeat frames on a regular basis (which we do)
and receive some on the same regular basis, but not answer to the ones we receive.

Eventually we should check that we got the heartbeat from the server at the right pace.