### PR TITLE
futures: channel cleanup and assorted fixes

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -87,7 +87,7 @@ assert!(conn.check_state(channel_id, ChannelState::Connected).unwrap_or(false));
 let request_id: u16 = conn.queue_declare(channel_id, 0, "hello".to_string(), false, false, false, false, false, HashMap::new()).unwrap();
 
 // update state here until:
-assert!(conn.is_finished(request_id));
+assert!(conn.is_finished(request_id).unwrap_or(false));
 ```
 
 ## Publishing a message
@@ -107,7 +107,7 @@ conn.send_content_frames(channel_a, 60, payload, basic::Properties::default()));
 let request_id: u16 = conn.basic_consume(channel_id, 0, "hello".to_string(), "my_consumer".to_string(), false, true, false, false, HashMap::new()).expect("basic_consume");
 
 // update state here until:
-assert!(conn.is_finished(request_id));
+assert!(conn.is_finished(request_id).unwrap_or(false));
 
 // get the next message
 if let Ok(message) = conn.next_message(channel_id, "hello", "my_consumer") {

--- a/async/src/api.rs
+++ b/async/src/api.rs
@@ -181,7 +181,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingChannelOpenOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
           },
           _ => {
             self.set_channel_state(_channel_id, ChannelState::Error);
@@ -261,7 +261,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingChannelFlowOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| c.receive_flow = method.active);
             self.get_next_answer(_channel_id);
           },
@@ -356,7 +356,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingChannelCloseOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.set_channel_state(_channel_id, ChannelState::Closed);
           },
           _ => {
@@ -423,7 +423,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingAccessRequestOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -492,7 +492,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingExchangeDeclareOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -552,7 +552,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingExchangeDeleteOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -616,7 +616,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingExchangeBindOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -680,7 +680,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingExchangeUnbindOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -750,7 +750,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingQueueDeclareOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| {
               c.queues.get_mut(&method.queue).map(|q| {
                 q.message_count  = method.message_count;
@@ -825,7 +825,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingQueueBindOk(request_id, exchange, routing_key)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             let key = (exchange, routing_key);
             self.channels.get_mut(&_channel_id).map(|c| {
               for ref mut q in c.queues.values_mut() {
@@ -889,7 +889,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingQueuePurgeOk(request_id, _)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             Ok(())
           },
           _ => {
@@ -950,7 +950,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingQueueDeleteOk(request_id, key)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| c.queues.remove(&key));
             Ok(())
           },
@@ -1012,7 +1012,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingQueueUnbindOk(request_id, exchange, routing_key)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             let key = (exchange, routing_key);
             self.channels.get_mut(&_channel_id).map(|c| {
               for ref mut q in c.queues.values_mut() {
@@ -1075,7 +1075,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingBasicQosOk(request_id, prefetch_size, prefetch_count, global)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             if global {
               self.prefetch_size  = prefetch_size;
               self.prefetch_count = prefetch_count;
@@ -1153,7 +1153,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingBasicConsumeOk(request_id, queue, _, no_local, no_ack, exclusive, nowait)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| {
               c.queues.get_mut(&queue).map(|q| {
                 let consumer = Consumer {
@@ -1225,7 +1225,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingBasicCancelOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| {
               for ref mut q in c.queues.values_mut() {
                 q.consumers.remove(&method.consumer_tag);
@@ -1521,7 +1521,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingBasicRecoverOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             error!("unimplemented method Basic.RecoverOk, ignoring packet");
             Ok(())
           },
@@ -1762,7 +1762,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingConfirmSelectOk(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
             self.channels.get_mut(&_channel_id).map(|c| {
               c.confirm = true;
               c.message_count = 1;
@@ -1791,7 +1791,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingPublishConfirm(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
 
             self.channels.get_mut(&_channel_id).map(|c| {
               if c.confirm {
@@ -1831,7 +1831,7 @@ impl Connection {
 
         match self.get_next_answer(_channel_id) {
           Some(Answer::AwaitingPublishConfirm(request_id)) => {
-            self.finished_reqs.insert(request_id);
+            self.finished_reqs.insert(request_id, true);
 
             self.channels.get_mut(&_channel_id).map(|c| {
               if c.confirm {

--- a/async/src/connection.rs
+++ b/async/src/connection.rs
@@ -1,7 +1,7 @@
 use std::{result,str};
 use std::default::Default;
 use std::io::{Error,ErrorKind,Result};
-use std::collections::{HashSet,HashMap,VecDeque};
+use std::collections::{HashMap,VecDeque};
 use nom::{IResult,Offset};
 use sasl;
 use sasl::client::Mechanism;
@@ -89,7 +89,7 @@ pub struct Connection {
   /// next request id
   pub request_index:     RequestId,
   /// list of finished requests
-  pub finished_reqs:     HashSet<RequestId>,
+  pub finished_reqs:     HashMap<RequestId, bool>,
   /// list of finished basic get requests
   pub finished_get_reqs: HashMap<RequestId, bool>,
   /// credentials are stored in an option to remove them from memory once they are used
@@ -114,7 +114,7 @@ impl Connection {
       prefetch_count:    0,
       frame_queue:       VecDeque::new(),
       request_index:     0,
-      finished_reqs:     HashSet::new(),
+      finished_reqs:     HashMap::new(),
       finished_get_reqs: HashMap::new(),
       credentials:       None,
     }
@@ -218,7 +218,7 @@ impl Connection {
   ///
   /// this method can only be called once per request id, as it will be
   /// removed from the list afterwards
-  pub fn is_finished(&mut self, id: RequestId) -> bool {
+  pub fn is_finished(&mut self, id: RequestId) -> Option<bool> {
     self.finished_reqs.remove(&id)
   }
 

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -87,7 +87,7 @@
 //! let request_id: u16 = conn.queue_declare(channel_id, 0, "hello".to_string(), false, false, false, false, false, HashMap::new()).unwrap();
 //!
 //! // update state here until:
-//! assert!(conn.is_finished(request_id));
+//! assert!(conn.is_finished(request_id).unwrap_or(false));
 //! ```
 //!
 //! ## Publishing a message
@@ -107,7 +107,7 @@
 //! let request_id: u16 = conn.basic_consume(channel_id, 0, "hello".to_string(), "my_consumer".to_string(), false, true, false, false, HashMap::new()).expect("basic_consume");
 //!
 //! // update state here until:
-//! assert!(conn.is_finished(request_id));
+//! assert!(conn.is_finished(request_id).unwrap_or(false));
 //!
 //! // get the next message
 //! if let Ok(message) = conn.next_message(channel_id, "hello", "my_consumer") {

--- a/futures/README.md
+++ b/futures/README.md
@@ -55,7 +55,7 @@ fn main() {
       // we using a "move" closure to reuse the channel
       // once the queue is declared. We could also clone
       // the channel
-      channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+      channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
         info!("channel {} declared queue {}", id, "hello");
 
           channel.basic_publish("hello", b"hello from tokio", &BasicPublishOptions::default(),
@@ -106,13 +106,13 @@ fn main() {
       info!("created channel with id: {}", id);
 
       let ch = channel.clone();
-      channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+      channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
         info!("channel {} declared queue {}", id, "hello");
 
         // basic_consume returns a future of a message
         // stream. Any time a message arrives for this consumer,
         // the for_each method would be called
-        channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
+        channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), &FieldTable::new())
       }).and_then(|stream| {
         info!("got consumer stream");
 

--- a/futures/README.md
+++ b/futures/README.md
@@ -112,7 +112,7 @@ fn main() {
         // basic_consume returns a future of a message
         // stream. Any time a message arrives for this consumer,
         // the for_each method would be called
-        channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default())
+        channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
       }).and_then(|stream| {
         info!("got consumer stream");
 

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -72,7 +72,7 @@ fn main() {
             info!("decoded message: {:?}", std::str::from_utf8(&message.data).unwrap());
             channel.basic_ack(message.delivery_tag)
           }).and_then(move |_| {
-            ch.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default())
+            ch.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
           })
         }).and_then(|stream| {
           info!("got consumer stream");

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -10,7 +10,7 @@ use tokio_core::reactor::Core;
 use tokio_core::net::TcpStream;
 use lapin::types::FieldTable;
 use lapin::client::ConnectionOptions;
-use lapin::channel::{BasicConsumeOptions,BasicGetOptions,BasicPublishOptions,BasicProperties,ExchangeBindOptions,ExchangeUnbindOptions,ExchangeDeclareOptions,ExchangeDeleteOptions,QueueBindOptions,QueueDeclareOptions};
+use lapin::channel::{BasicConsumeOptions,BasicGetOptions,BasicPublishOptions,BasicProperties,ConfirmSelectOptions,ExchangeBindOptions,ExchangeUnbindOptions,ExchangeDeclareOptions,ExchangeDeleteOptions,QueueBindOptions,QueueDeclareOptions};
 
 fn main() {
   env_logger::init().unwrap();
@@ -27,7 +27,7 @@ fn main() {
       })
     }).and_then(|client| {
 
-      client.create_confirm_channel().and_then(|channel| {
+      client.create_confirm_channel(ConfirmSelectOptions::default()).and_then(|channel| {
         let id = channel.id;
         info!("created channel with id: {}", id);
 

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -48,7 +48,7 @@ fn main() {
                 channel.exchange_bind("hello_exchange", "amq.direct", "test_bind", &ExchangeBindOptions::default(), FieldTable::new()).and_then(move |_| {
                     channel.exchange_unbind("hello_exchange", "amq.direct", "test_bind", &ExchangeUnbindOptions::default(), FieldTable::new()).and_then(move |_| {
                         channel.exchange_delete("hello_exchange", &ExchangeDeleteOptions::default()).and_then(move |_| {
-                            channel.close(200, "Bye".to_string())
+                            channel.close(200, "Bye")
                         })
                     })
                 })

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -31,11 +31,11 @@ fn main() {
         let id = channel.id;
         info!("created channel with id: {}", id);
 
-        channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+        channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
           info!("channel {} declared queue {}", id, "hello");
 
-          channel.exchange_declare("hello_exchange", "direct", &ExchangeDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
-            channel.queue_bind("hello", "hello_exchange", "hello_2", &QueueBindOptions::default(), FieldTable::new()).and_then(move |_| {
+          channel.exchange_declare("hello_exchange", "direct", &ExchangeDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
+            channel.queue_bind("hello", "hello_exchange", "hello_2", &QueueBindOptions::default(), &FieldTable::new()).and_then(move |_| {
               channel.basic_publish(
                 "hello_exchange",
                 "hello_2",
@@ -45,8 +45,8 @@ fn main() {
               ).map(|confirmation| {
                 info!("publish got confirmation: {:?}", confirmation)
               }).and_then(move |_| {
-                channel.exchange_bind("hello_exchange", "amq.direct", "test_bind", &ExchangeBindOptions::default(), FieldTable::new()).and_then(move |_| {
-                    channel.exchange_unbind("hello_exchange", "amq.direct", "test_bind", &ExchangeUnbindOptions::default(), FieldTable::new()).and_then(move |_| {
+                channel.exchange_bind("hello_exchange", "amq.direct", "test_bind", &ExchangeBindOptions::default(), &FieldTable::new()).and_then(move |_| {
+                    channel.exchange_unbind("hello_exchange", "amq.direct", "test_bind", &ExchangeUnbindOptions::default(), &FieldTable::new()).and_then(move |_| {
                         channel.exchange_delete("hello_exchange", &ExchangeDeleteOptions::default()).and_then(move |_| {
                             channel.close(200, "Bye")
                         })
@@ -63,7 +63,7 @@ fn main() {
         info!("created channel with id: {}", id);
 
         let c = channel.clone();
-        channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+        channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
           info!("channel {} declared queue {}", id, "hello");
 
           let ch = channel.clone();
@@ -72,7 +72,7 @@ fn main() {
             info!("decoded message: {:?}", std::str::from_utf8(&message.data).unwrap());
             channel.basic_ack(message.delivery_tag)
           }).and_then(move |_| {
-            ch.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
+            ch.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), &FieldTable::new())
           })
         }).and_then(|stream| {
           info!("got consumer stream");

--- a/futures/examples/tls.rs
+++ b/futures/examples/tls.rs
@@ -9,6 +9,7 @@ extern crate webpki_roots;
 
 use futures::future::Future;
 use lapin::client::ConnectionOptions;
+use lapin::channel::ConfirmSelectOptions;
 use rustls::ClientConfig;
 use std::sync::Arc;
 use tokio_core::reactor::Core;
@@ -40,7 +41,7 @@ fn main() {
         ..Default::default()
       })
     }).and_then(|client| {
-      client.create_confirm_channel().and_then(|channel| {
+      client.create_confirm_channel(ConfirmSelectOptions::default()).and_then(|channel| {
         let id = channel.id;
         info!("created channel with id: {}", id);
         Ok(())

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -373,7 +373,22 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         if let Ok(mut transport) = self.transport.lock() {
             match action(&mut transport) {
                 Err(e)         => Box::new(future::err(Error::new(ErrorKind::Other, format!("{}: {:?}", error, e)))),
-                Ok(request_id) => Self::process_frames(&mut transport, method, request_id.map(|request_id| (request_id, self.transport.clone(), finished, no_answer))),
+                Ok(request_id) => {
+                    trace!("{} request id: {:?}", method, request_id);
+
+                    if let Err(e) = transport.send_and_handle_frames() {
+                        let err = format!("Failed to handle frames: {:?}", e);
+                        trace!("{}", err);
+                        return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+                    }
+
+                    if let Some(request_id) = request_id {
+                        trace!("{} returning closure", method);
+                        Box::new(Self::wait_for_answer(self.transport.clone(), request_id, finished, no_answer).map(|_| ()))
+                    } else {
+                        Box::new(future::ok(()))
+                    }
+                },
             }
         } else {
             //FIXME: if we're there, it means the mutex failed
@@ -386,46 +401,23 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         self.run_on_locked_transport_full(method, error, action, Connection::is_finished, || Ok(Async::NotReady))
     }
 
-    fn process_frames<Finished, NoAnswer>(transport: &mut AMQPTransport<T>, method: &str, request_id_data: Option<(RequestId, Arc<Mutex<AMQPTransport<T>>>, Finished, NoAnswer)>) -> Box<Future<Item = (), Error = io::Error>>
-        where Finished: 'static + Fn(&mut Connection, RequestId) -> Option<bool>,
-              NoAnswer: 'static + Fn() -> Poll<bool, io::Error> {
-        trace!("{} request id: {:?}", method, request_id_data.as_ref().map(|r| r.0));
-        if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-        }
-
-        if let Some((request_id, cl_transport, finished, no_answer)) = request_id_data {
-            trace!("{} returning closure", method);
-            Box::new(Self::wait_for_answer(cl_transport, request_id, finished, no_answer).map(|_| ()))
-        } else {
-            Box::new(future::ok(()))
-        }
-    }
-
     /// internal method to wait until a request succeeds
     pub fn wait_for_answer<Finished, NoAnswer>(transport: Arc<Mutex<AMQPTransport<T>>>, request_id: RequestId, finished: Finished, no_answer: NoAnswer) -> Box<Future<Item = bool, Error = io::Error>>
         where Finished: 'static + Fn(&mut Connection, RequestId) -> Option<bool>,
               NoAnswer: 'static + Fn() -> Poll<bool, io::Error> {
         trace!("wait for answer for request {}", request_id);
         Box::new(future::poll_fn(move || {
-            let got_answer = if let Ok(mut tr) = transport.try_lock() {
+            if let Ok(mut tr) = transport.try_lock() {
                 tr.handle_frames()?;
-                if let Some(res) = finished(&mut tr.conn, request_id) {
-                    res
-                } else {
-                    return Ok(Async::NotReady);
+                if let Some(got_answer) = finished(&mut tr.conn, request_id) {
+                    return if got_answer {
+                        Ok(Async::Ready(got_answer))
+                    } else {
+                        no_answer()
+                    };
                 }
-            } else {
-                return Ok(Async::NotReady);
-            };
-
-            if got_answer {
-                Ok(Async::Ready(got_answer))
-            } else {
-                no_answer()
             }
+            Ok(Async::NotReady)
         }))
     }
 }

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -137,10 +137,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not request access"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -162,10 +159,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not declare exchange"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -186,10 +180,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not delete exchange"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -210,10 +201,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not bind exchange"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -234,10 +222,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not delete exchange"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -262,10 +247,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -287,10 +269,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -308,10 +287,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-      Error::new(ErrorKind::ConnectionAborted, format!("could not activate confirm extension"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -353,10 +329,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -398,10 +371,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -417,10 +387,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -436,10 +403,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -462,10 +426,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not create channel"))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -485,10 +446,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not purge queue {}", queue_name))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -514,10 +472,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not delete queue {}", queue_name))
-      ))
+        Self::mutex_failed()
     }
   }
 
@@ -533,11 +488,13 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
         },
       }
     } else {
-      //FIXME: if we're there, it means the mutex failed
-      Box::new(future::err(
-        Error::new(ErrorKind::ConnectionAborted, format!("could not close channel"))
-      ))
+        Self::mutex_failed()
     }
+  }
+
+  fn mutex_failed<I: 'static>() -> Box<Future<Item = I, Error = io::Error>> {
+      //FIXME: if we're there, it means the mutex failed
+      Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, "Failed to acquire AMQPTransport mutex")))
   }
 
   fn process_frames(transport: &mut AMQPTransport<T>, cl_transport: Option<Arc<Mutex<AMQPTransport<T>>>>, method: &str, request_id: Option<RequestId>) -> Box<Future<Item = (), Error = io::Error>> {

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -163,7 +163,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     /// declares an exchange
     ///
     /// returns a future that resolves once the exchange is available
-    pub fn exchange_declare(&self, name: &str, exchange_type: &str, options: &ExchangeDeclareOptions, arguments: FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_declare(&self, name: &str, exchange_type: &str, options: &ExchangeDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
         self.run_on_locked_transport("exchange_declare", "Could not declare exchange", |mut transport| {
             transport.conn.exchange_declare(self.id, options.ticket, name.to_string(), exchange_type.to_string(),
                 options.passive, options.durable, options.auto_delete, options.internal, options.nowait, arguments.clone()).map(Some)
@@ -183,7 +183,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     /// binds an exchange to another exchange
     ///
     /// returns a future that resolves once the exchanges are bound
-    pub fn exchange_bind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeBindOptions, arguments: FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_bind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
         self.run_on_locked_transport("exchange_bind", "Could not bind exchange", |mut transport| {
             transport.conn.exchange_bind(self.id, options.ticket, destination.to_string(), source.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -193,7 +193,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     /// unbinds an exchange from another one
     ///
     /// returns a future that resolves once the exchanges are unbound
-    pub fn exchange_unbind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeUnbindOptions, arguments: FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_unbind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeUnbindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
         self.run_on_locked_transport("exchange_unbind", "Could not unbind exchange", |mut transport| {
             transport.conn.exchange_unbind(self.id, options.ticket, destination.to_string(), source.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -206,7 +206,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     ///
     /// the `mandatory` and `ìmmediate` options can be set to true,
     /// but the return message will not be handled
-    pub fn queue_declare(&self, name: &str, options: &QueueDeclareOptions, arguments: FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_declare(&self, name: &str, options: &QueueDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
         self.run_on_locked_transport("queue_declare", "Could not declare queue", |mut transport| {
             transport.conn.queue_declare(self.id, options.ticket, name.to_string(),
                 options.passive, options.durable, options.exclusive, options.auto_delete, options.nowait, arguments.clone()).map(Some)
@@ -216,7 +216,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     /// binds a queue to an exchange
     ///
     /// returns a future that resolves once the queue is bound to the exchange
-    pub fn queue_bind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueBindOptions, arguments: FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_bind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
         self.run_on_locked_transport("queue_bind", "Could not bind queue", |mut transport| {
             transport.conn.queue_bind(self.id, options.ticket, name.to_string(), exchange.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -266,7 +266,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
     ///
     /// `Consumer` implements `futures::Stream`, so it can be used with any of
     /// the usual combinators
-    pub fn basic_consume(&self, queue: &str, consumer_tag: &str, options: &BasicConsumeOptions, arguments: FieldTable) -> Box<Future<Item = Consumer<T>, Error = io::Error>> {
+    pub fn basic_consume(&self, queue: &str, consumer_tag: &str, options: &BasicConsumeOptions, arguments: &FieldTable) -> Box<Future<Item = Consumer<T>, Error = io::Error>> {
         let consumer = Consumer {
             transport:    self.transport.clone(),
             channel_id:   self.id,

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -2,6 +2,7 @@ use std::io::{self,Error,ErrorKind};
 use futures::{Async,Future,future,Stream};
 use tokio_io::{AsyncRead,AsyncWrite};
 use std::sync::{Arc,Mutex};
+use lapin_async;
 use lapin_async::api::RequestId;
 use lapin_async::queue::Message;
 use lapin_async::generated::basic;
@@ -477,19 +478,21 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
   }
 
   /// closes the cannel
-  pub fn close(&self, code: u16, message: String) -> Box<Future<Item = (), Error = io::Error>> {
-    if let Ok(mut transport) = self.transport.lock() {
-      match transport.conn.channel_close(self.id, code, message, 0, 0) {
-        Err(e) => Box::new(
-          future::err(Error::new(ErrorKind::Other, format!("could not close channel: {:?}", e)))
-        ),
-        Ok(request_id) => {
-          Self::process_frames(&mut transport, None, "close", Some(request_id))
-        },
+  pub fn close(&self, code: u16, message: &str) -> Box<Future<Item = (), Error = io::Error>> {
+      self.run_on_locked_transport(None, "close", "Could not close channel", |mut transport| {
+          transport.conn.channel_close(self.id, code, message.to_string(), 0, 0).map(|_| None)
+      })
+  }
+
+  fn run_on_locked_transport<F: FnMut(&mut AMQPTransport<T>) -> Result<Option<RequestId>, lapin_async::error::Error>>(&self, cl_transport: Option<Arc<Mutex<AMQPTransport<T>>>>, method: &str, error: &str, mut action: F) -> Box<Future<Item = (), Error = io::Error>> {
+      if let Ok(mut transport) = self.transport.lock() {
+          match action(&mut transport) {
+              Err(e)         => Box::new(future::err(Error::new(ErrorKind::Other, format!("{}: {:?}", error, e)))),
+              Ok(request_id) => Self::process_frames(&mut transport, cl_transport, method, request_id),
+          }
+      } else {
+          Self::mutex_failed()
       }
-    } else {
-        Self::mutex_failed()
-    }
   }
 
   fn mutex_failed<I: 'static>() -> Box<Future<Item = I, Error = io::Error>> {

--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -133,15 +133,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not request access {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("access_request request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("access_request returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "access_request", request_id)
         },
       }
     } else {
@@ -166,15 +158,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not declare exchange: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("exchange_declare request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("exchange_declare returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "exchange_declare", request_id)
         },
       }
     } else {
@@ -198,15 +182,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not delete exchange: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("exchange_delete request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("exchange_delete returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "exchange_delete", request_id)
         },
       }
     } else {
@@ -230,15 +206,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not bind exchange: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("exchange_bind request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("exchange_bind returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "exchange_bind", request_id)
         },
       }
     } else {
@@ -262,15 +230,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not unbind exchange: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("exchange_unbind request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("exchange_unbind returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "exchange_unbind", request_id)
         },
       }
     } else {
@@ -298,15 +258,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not declare queue: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("queue_declare request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("queue_declare returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "queue_declare", request_id)
         },
       }
     } else {
@@ -331,15 +283,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not bind queue: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("queue_bind request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("queue_bind returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "queue_bind", request_id)
         },
       }
     } else {
@@ -360,14 +304,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not activate confirm extension: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("confirm select request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "confirm_select", request_id)
         },
       }
     } else {
@@ -438,6 +375,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not start consumer: {:?}", e)))
         ),
         Ok(request_id) => {
+          //TODO: Self::process_frames(&mut transport, cl_transport, "basic_consume", request_id)
           if let Err(e) = transport.send_and_handle_frames() {
             let err = format!("Failed to handle frames: {:?}", e);
             trace!("{}", err);
@@ -523,6 +461,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not publish: {:?}", e)))
         ),
         Ok(request_id) => {
+          //TODO: Self::process_frames(&mut transport, cl_transport, "basic_get", request_id)
           if let Err(e) = transport.send_and_handle_frames() {
             let err = format!("Failed to handle frames: {:?}", e);
             trace!("{}", err);
@@ -551,15 +490,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not purge queue: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("purge request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("purge returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "queue_purge", request_id)
         },
       }
     } else {
@@ -588,15 +519,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
           future::err(Error::new(ErrorKind::ConnectionAborted, format!("could not delete queue: {:?}", e)))
         ),
         Ok(request_id) => {
-          trace!("delete request id: {}", request_id);
-          if let Err(e) = transport.send_and_handle_frames() {
-            let err = format!("Failed to handle frames: {:?}", e);
-            trace!("{}", err);
-            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
-          }
-
-          trace!("delete returning closure");
-          wait_for_answer(cl_transport, request_id)
+          Self::process_frames(&mut transport, cl_transport, "queue_delete", request_id)
         },
       }
     } else {
@@ -630,6 +553,18 @@ impl<T: AsyncRead+AsyncWrite+'static> Channel<T> {
       ))
     }
   }
+
+    fn process_frames(transport: &mut AMQPTransport<T>, cl_transport: Arc<Mutex<AMQPTransport<T>>>, method: &str, request_id: RequestId) -> Box<Future<Item = (), Error = io::Error>> {
+        trace!("{} request id: {}", method, request_id);
+        if let Err(e) = transport.send_and_handle_frames() {
+            let err = format!("Failed to handle frames: {:?}", e);
+            trace!("{}", err);
+            return Box::new(future::err(Error::new(ErrorKind::ConnectionAborted, err)));
+        }
+
+        trace!("{} returning closure", method);
+        wait_for_answer(cl_transport, request_id)
+    }
 }
 
 /// internal method to wait until a basic get succeeded

--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -7,7 +7,7 @@ use tokio_io::{AsyncRead,AsyncWrite};
 use std::sync::{Arc,Mutex};
 
 use transport::*;
-use channel::{Channel, ConfirmSelectOptions, wait_for_answer};
+use channel::{Channel, ConfirmSelectOptions};
 
 /// the Client structures connects to a server and creates channels
 #[derive(Clone)]
@@ -74,7 +74,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Client<T> {
           }
 
           //FIXME: very afterwards that the state is Connected and not error
-          Box::new(wait_for_answer(channel_transport.clone(), request_id, Connection::is_finished, || Ok(Async::NotReady)).map(move |_| {
+          Box::new(Channel::wait_for_answer(channel_transport.clone(), request_id, Connection::is_finished, || Ok(Async::NotReady)).map(move |_| {
             Channel {
               id:        channel_id,
               transport: channel_transport,

--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -2,8 +2,7 @@ use lapin_async::connection::Connection;
 
 use std::default::Default;
 use std::io::{self,Error,ErrorKind};
-use futures::Future;
-use futures::future;
+use futures::{Async,future,Future};
 use tokio_io::{AsyncRead,AsyncWrite};
 use std::sync::{Arc,Mutex};
 
@@ -75,7 +74,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Client<T> {
           }
 
           //FIXME: very afterwards that the state is Connected and not error
-          Box::new(wait_for_answer(channel_transport.clone(), request_id, Connection::is_finished).map(move |_| {
+          Box::new(wait_for_answer(channel_transport.clone(), request_id, Connection::is_finished, || Ok(Async::NotReady)).map(move |_| {
             Channel {
               id:        channel_id,
               transport: channel_transport,

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -22,7 +22,7 @@ impl<T: AsyncRead+AsyncWrite+'static> Stream for Consumer<T> {
   fn poll(&mut self) -> Poll<Option<Message>, io::Error> {
     trace!("consumer[{}] poll", self.consumer_tag);
     if let Ok(mut transport) = self.transport.try_lock() {
-      transport.handle_frames()?;
+      transport.send_and_handle_frames()?;
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
         transport.poll()?;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -111,7 +111,7 @@
 //!         // basic_consume returns a future of a message
 //!         // stream. Any time a message arrives for this consumer,
 //!         // the for_each method would be called
-//!         channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default())
+//!         channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
 //!       }).and_then(|stream| {
 //!         info!("got consumer stream");
 //!

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -55,7 +55,7 @@
 //!       // we using a "move" closure to reuse the channel
 //!       // once the queue is declared. We could also clone
 //!       // the channel
-//!       channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+//!       channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
 //!         info!("channel {} declared queue {}", id, "hello");
 //!
 //!         channel.basic_publish("", "hello", b"hello from tokio", &BasicPublishOptions::default(), BasicProperties::default())
@@ -105,13 +105,13 @@
 //!       info!("created channel with id: {}", id);
 //!
 //!       let ch = channel.clone();
-//!       channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+//!       channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
 //!         info!("channel {} declared queue {}", id, "hello");
 //!
 //!         // basic_consume returns a future of a message
 //!         // stream. Any time a message arrives for this consumer,
 //!         // the for_each method would be called
-//!         channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
+//!         channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), &FieldTable::new())
 //!       }).and_then(|stream| {
 //!         info!("got consumer stream");
 //!

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -222,7 +222,7 @@ impl<T> AMQPTransport<T>
       self.start_send(frame).and_then(|_| self.poll_complete())
   }
 
-  pub fn handle_frames(&mut self) -> Poll<Option<()>, io::Error> {
+  fn handle_frames(&mut self) -> Poll<Option<()>, io::Error> {
     trace!("handle frames");
     for _ in 0..30 {
       if try_ready!(self.poll()).is_none() {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -13,6 +13,7 @@ use futures::{Async,Poll,Sink,Stream,StartSend,Future,future};
 use tokio_io::{AsyncRead,AsyncWrite};
 use tokio_io::codec::{Decoder,Encoder,Framed};
 use tokio_timer::{Interval,Timer};
+use channel::BasicProperties;
 use client::ConnectionOptions;
 
 /// implements tokio-io's Decoder and Encoder
@@ -197,6 +198,12 @@ impl<T> AMQPTransport<T>
   pub fn send_and_handle_frames(&mut self) -> Poll<Option<()>, io::Error> {
     self.send_frames()?;
     self.handle_frames()
+  }
+
+  pub fn send_and_handle_frames_with_payload(&mut self, channel_id: u16, payload: &[u8], properties: BasicProperties) -> Poll<Option<()>, io::Error> {
+      self.send_and_handle_frames()?;
+      self.conn.send_content_frames(channel_id, 60, payload, properties);
+      self.send_and_handle_frames()
   }
 
   fn send_frames(&mut self) -> Result<(), io::Error> {

--- a/futures/tests/connection.rs
+++ b/futures/tests/connection.rs
@@ -48,7 +48,7 @@ fn connection() {
         channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
           info!("channel {} declared queue {}", id, "hello");
 
-          channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default())
+          channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
         }).and_then(move |stream| {
           info!("got consumer stream");
 

--- a/futures/tests/connection.rs
+++ b/futures/tests/connection.rs
@@ -30,7 +30,7 @@ fn connection() {
         let id = channel.id;
         info!("created channel with id: {}", id);
 
-        channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+        channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
           info!("channel {} declared queue {}", id, "hello");
 
           channel.queue_purge("hello", &QueuePurgeOptions::default()).and_then(move |_| {
@@ -45,10 +45,10 @@ fn connection() {
 
         let ch1 = channel.clone();
         let ch2 = channel.clone();
-        channel.queue_declare("hello", &QueueDeclareOptions::default(), FieldTable::new()).and_then(move |_| {
+        channel.queue_declare("hello", &QueueDeclareOptions::default(), &FieldTable::new()).and_then(move |_| {
           info!("channel {} declared queue {}", id, "hello");
 
-          channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), FieldTable::new())
+          channel.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), &FieldTable::new())
         }).and_then(move |stream| {
           info!("got consumer stream");
 


### PR DESCRIPTION
This PR introduces Channel::run_on_locked_transport which is now used in all the other methods.
Client::create_channel now uses a new Channel::create which uses the run_on_locked_transport method from above.

This avoids lots of duplicate code.