### PR TITLE
futures: cleanup

### DIFF
--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -1,5 +1,5 @@
 use std::io::{self,Error,ErrorKind};
-use futures::{Async,Future,future,Poll,Stream};
+use futures::{Async,Future,future,Poll};
 use tokio_io::{AsyncRead,AsyncWrite};
 use std::sync::{Arc,Mutex};
 use lapin_async;
@@ -309,7 +309,6 @@ impl<T: AsyncRead+AsyncWrite+Sync+Send+'static> Channel<T> {
                 if let Some(message) = transport.conn.next_get_message(channel_id, &_queue) {
                     Ok(Async::Ready(message))
                 } else {
-                    transport.poll()?;
                     trace!("basic get[{}-{}] not ready", channel_id, _queue);
                     Ok(Async::NotReady)
                 }

--- a/futures/src/consumer.rs
+++ b/futures/src/consumer.rs
@@ -25,11 +25,9 @@ impl<T: AsyncRead+AsyncWrite+Sync+Send+'static> Stream for Consumer<T> {
       transport.send_and_handle_frames()?;
       //FIXME: if the consumer closed, we should return Ok(Async::Ready(None))
       if let Some(message) = transport.conn.next_message(self.channel_id, &self.queue, &self.consumer_tag) {
-        transport.poll()?;
         trace!("consumer[{}] ready", self.consumer_tag);
         Ok(Async::Ready(Some(message)))
       } else {
-        transport.poll()?;
         trace!("consumer[{}] not ready", self.consumer_tag);
         Ok(Async::NotReady)
       }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -153,6 +153,11 @@ impl<T> AMQPTransport<T>
     Box::new(connector)
   }
 
+  // Note that this can only return one of
+  // - Error
+  // - Async::NotReady
+  // - Async::Ready(None)
+  // All other results are handled until one of these three is reached.
   pub fn send_and_handle_frames(&mut self) -> Poll<Option<()>, io::Error> {
     self.send_frames()?;
     self.handle_frames()

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -182,12 +182,12 @@ impl<T> AMQPTransport<T>
 
   fn handle_frames(&mut self) -> Poll<Option<()>, io::Error> {
     trace!("handle frames");
-    for _ in 0..30 {
+    loop {
+      // try_ready will return if we hit an error or NotReady.
       if try_ready!(self.poll()).is_none() {
         return Ok(Async::Ready(None));
       }
     }
-    self.poll()
   }
 }
 


### PR DESCRIPTION
Drop unnecessary calls to poll (redundant with the send_and_handle_frames above).
Really loop until we hit an error, a NotReady or a Ready(None) in handle_frames.