### PR TITLE
Messages rework

### DIFF
--- a/async/README.md
+++ b/async/README.md
@@ -110,7 +110,7 @@ let request_id: u16 = conn.basic_consume(channel_id, 0, "hello".to_string(), "my
 assert!(conn.is_finished(request_id).unwrap_or(false));
 
 // get the next message
-if let Ok(message) = conn.next_message(channel_id, "hello", "my_consumer") {
+if let Ok(message) = conn.next_delivery(channel_id, "hello", "my_consumer") {
  // handle message
 }
 ```

--- a/async/examples/connection.rs
+++ b/async/examples/connection.rs
@@ -83,7 +83,7 @@ fn main() {
       info!("[{}] state: {:?}", line!(), conn.run(&mut stream, &mut send_buffer, &mut receive_buffer).unwrap());
       thread::sleep(time::Duration::from_millis(100));
       info!("[{}] state: {:?}", line!(), conn.run(&mut stream, &mut send_buffer, &mut receive_buffer).unwrap());
-      info!("received message: {:?}", conn.next_message(channel_b, "hello", "my_consumer").unwrap());
+      info!("received message: {:?}", conn.next_delivery(channel_b, "hello", "my_consumer").unwrap());
       panic!();
 }
 

--- a/async/src/api.rs
+++ b/async/src/api.rs
@@ -1,5 +1,6 @@
 use connection::*;
 use queue::*;
+use message::*;
 use generated::*;
 use error::*;
 use types::*;
@@ -1317,7 +1318,7 @@ impl Connection {
             for (ref queue_name, ref mut q) in &mut c.queues {
               c.state = ChannelState::WillReceiveContent(queue_name.to_string(), Some(method.consumer_tag.to_string()));
               q.consumers.get_mut(&method.consumer_tag).map(|cs| {
-                cs.current_message = Some(Message::new(
+                cs.current_message = Some(Delivery::new(
                   method.delivery_tag,
                   method.exchange.to_string(),
                   method.routing_key.to_string(),
@@ -1382,11 +1383,12 @@ impl Connection {
 
             self.channels.get_mut(&_channel_id).map(|c| {
               c.queues.get_mut(&queue_name).map(|q| {
-                q.current_get_message = Some(Message::new(
+                q.current_get_message = Some(BasicGetMessage::new(
                   method.delivery_tag,
                   method.exchange.to_string(),
                   method.routing_key.to_string(),
-                  method.redelivered
+                  method.redelivered,
+                  method.message_count
                 ));
               })
             });

--- a/async/src/lib.rs
+++ b/async/src/lib.rs
@@ -129,6 +129,7 @@ pub mod io;
 pub mod connection;
 pub mod channel;
 pub mod queue;
+pub mod message;
 pub mod generated;
 pub mod format;
 pub mod api;

--- a/async/src/message.rs
+++ b/async/src/message.rs
@@ -1,0 +1,44 @@
+use generated::basic;
+use types::*;
+
+#[derive(Clone,Debug,PartialEq)]
+pub struct Delivery {
+  pub delivery_tag: LongLongUInt,
+  pub exchange:     String,
+  pub routing_key:  String,
+  pub redelivered:  bool,
+  pub properties:   basic::Properties,
+  pub data:         Vec<u8>,
+}
+
+impl Delivery {
+  pub fn new(delivery_tag: LongLongUInt, exchange: String, routing_key: String, redelivered: bool) -> Delivery {
+    Delivery {
+      delivery_tag,
+      exchange,
+      routing_key,
+      redelivered,
+      properties: basic::Properties::default(),
+      data:       Vec::new(),
+    }
+  }
+
+  pub fn receive_content(&mut self, data: Vec<u8>) {
+    self.data.extend(data);
+  }
+}
+
+#[derive(Clone,Debug,PartialEq)]
+pub struct BasicGetMessage {
+  pub delivery:      Delivery,
+  pub message_count: LongUInt,
+}
+
+impl BasicGetMessage {
+  pub fn new(delivery_tag: LongLongUInt, exchange: String, routing_key: String, redelivered: bool, message_count: LongUInt) -> BasicGetMessage {
+    BasicGetMessage {
+      delivery: Delivery::new(delivery_tag, exchange, routing_key, redelivered),
+      message_count,
+    }
+  }
+}

--- a/async/tests/connection.rs
+++ b/async/tests/connection.rs
@@ -82,7 +82,7 @@ fn connection() {
       println!("[{}] state: {:?}", line!(), conn.run(&mut stream, &mut send_buffer, &mut receive_buffer).unwrap());
       thread::sleep(time::Duration::from_millis(100));
       println!("[{}] state: {:?}", line!(), conn.run(&mut stream, &mut send_buffer, &mut receive_buffer).unwrap());
-      let msg = conn.next_message(channel_b, "hello-async", "my_consumer").unwrap();
+      let msg = conn.next_delivery(channel_b, "hello-async", "my_consumer").unwrap();
       println!("received message: {:?}", msg);
       println!("data: {}", std::str::from_utf8(&msg.data).unwrap());
 

--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -71,8 +71,8 @@ fn main() {
           let ch = channel.clone();
           channel.basic_get("hello", &BasicGetOptions::default()).and_then(move |message| {
             info!("got message: {:?}", message);
-            info!("decoded message: {:?}", std::str::from_utf8(&message.data).unwrap());
-            channel.basic_ack(message.delivery_tag)
+            info!("decoded message: {:?}", std::str::from_utf8(&message.delivery.data).unwrap());
+            channel.basic_ack(message.delivery.delivery_tag)
           }).and_then(move |_| {
             ch.basic_consume("hello", "my_consumer", &BasicConsumeOptions::default(), &FieldTable::new())
           })

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -147,4 +147,5 @@ pub mod client;
 pub mod transport;
 pub mod channel;
 pub mod consumer;
+pub mod message;
 pub mod types;

--- a/futures/src/message.rs
+++ b/futures/src/message.rs
@@ -1,0 +1,2 @@
+pub use lapin_async::message::*;
+


### PR DESCRIPTION
Make the distinction between BasicGetMessage and ConsumerMessage, reexport those in lapin-futures