### PR TITLE
Mark all returned `Future` as `Send`

### DIFF
--- a/futures/src/channel.rs
+++ b/futures/src/channel.rs
@@ -140,7 +140,7 @@ pub struct QueueDeleteOptions {
 
 impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// create a channel
-    pub fn create(transport: Arc<Mutex<AMQPTransport<T>>>) -> Box<Future<Item = Self, Error = io::Error>> {
+    pub fn create(transport: Arc<Mutex<AMQPTransport<T>>>) -> Box<Future<Item = Self, Error = io::Error> + Send> {
         let channel_transport = transport.clone();
         let create_channel = future::poll_fn(move || {
             if let Ok(mut transport) = channel_transport.try_lock() {
@@ -166,7 +166,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// request access
     ///
     /// returns a future that resolves once the access is granted
-    pub fn access_request(&self, realm: &str, options: &AccessRequestOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn access_request(&self, realm: &str, options: &AccessRequestOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("access_request", "Could not request access", |transport| {
             transport.conn.access_request(self.id, realm.to_string(),
                 options.exclusive, options.passive, options.active, options.write, options.read).map(Some)
@@ -176,7 +176,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// declares an exchange
     ///
     /// returns a future that resolves once the exchange is available
-    pub fn exchange_declare(&self, name: &str, exchange_type: &str, options: &ExchangeDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_declare(&self, name: &str, exchange_type: &str, options: &ExchangeDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("exchange_declare", "Could not declare exchange", |transport| {
             transport.conn.exchange_declare(self.id, options.ticket, name.to_string(), exchange_type.to_string(),
                 options.passive, options.durable, options.auto_delete, options.internal, options.nowait, arguments.clone()).map(Some)
@@ -186,7 +186,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// deletes an exchange
     ///
     /// returns a future that resolves once the exchange is deleted
-    pub fn exchange_delete(&self, name: &str, options: &ExchangeDeleteOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_delete(&self, name: &str, options: &ExchangeDeleteOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("exchange_delete", "Could not delete exchange", |transport| {
             transport.conn.exchange_delete(self.id, options.ticket, name.to_string(),
                 options.if_unused, options.nowait).map(Some)
@@ -196,7 +196,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// binds an exchange to another exchange
     ///
     /// returns a future that resolves once the exchanges are bound
-    pub fn exchange_bind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_bind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("exchange_bind", "Could not bind exchange", |transport| {
             transport.conn.exchange_bind(self.id, options.ticket, destination.to_string(), source.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -206,7 +206,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// unbinds an exchange from another one
     ///
     /// returns a future that resolves once the exchanges are unbound
-    pub fn exchange_unbind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeUnbindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn exchange_unbind(&self, destination: &str, source: &str, routing_key: &str, options: &ExchangeUnbindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("exchange_unbind", "Could not unbind exchange", |transport| {
             transport.conn.exchange_unbind(self.id, options.ticket, destination.to_string(), source.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -219,7 +219,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     ///
     /// the `mandatory` and `ìmmediate` options can be set to true,
     /// but the return message will not be handled
-    pub fn queue_declare(&self, name: &str, options: &QueueDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_declare(&self, name: &str, options: &QueueDeclareOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("queue_declare", "Could not declare queue", |transport| {
             transport.conn.queue_declare(self.id, options.ticket, name.to_string(),
                 options.passive, options.durable, options.exclusive, options.auto_delete, options.nowait, arguments.clone()).map(Some)
@@ -229,7 +229,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// binds a queue to an exchange
     ///
     /// returns a future that resolves once the queue is bound to the exchange
-    pub fn queue_bind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_bind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueBindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("queue_bind", "Could not bind queue", |transport| {
             transport.conn.queue_bind(self.id, options.ticket, name.to_string(), exchange.to_string(), routing_key.to_string(),
                 options.nowait, arguments.clone()).map(Some)
@@ -239,21 +239,21 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// unbinds a queue from the exchange
     ///
     /// returns a future that resolves once the queue is unbound from the exchange
-    pub fn queue_unbind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueUnbindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_unbind(&self, name: &str, exchange: &str, routing_key: &str, options: &QueueUnbindOptions, arguments: &FieldTable) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("queue_unbind", "Could not unbind queue from the exchange", |transport| {
             transport.conn.queue_unbind(self.id, options.ticket, name.to_string(), exchange.to_string(), routing_key.to_string(), arguments.clone()).map(Some)
         })
     }
 
     /// sets up confirm extension for this channel
-    pub fn confirm_select(&self, options: &ConfirmSelectOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn confirm_select(&self, options: &ConfirmSelectOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("confirm_select", "Could not activate confirm extension", |transport| {
             transport.conn.confirm_select(self.id, options.nowait).map(Some)
         })
     }
 
     /// specifies quality of service for a channel
-    pub fn basic_qos(&self, options: &BasicQosOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn basic_qos(&self, options: &BasicQosOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("basic_qos", "Could not setup qos", |transport| {
             transport.conn.basic_qos(self.id, options.prefetch_size, options.prefetch_count, options.global).map(|_| None)
         })
@@ -265,7 +265,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// - `Some(true)` if we're on a confirm channel and the message was ack'd
     /// - `Some(false)` if we're on a confirm channel and the message was nack'd
     /// - `None` if we're not on a confirm channel
-    pub fn basic_publish(&self, exchange: &str, routing_key: &str, payload: &[u8], options: &BasicPublishOptions, properties: BasicProperties) -> Box<Future<Item = Option<bool>, Error = io::Error>> {
+    pub fn basic_publish(&self, exchange: &str, routing_key: &str, payload: &[u8], options: &BasicPublishOptions, properties: BasicProperties) -> Box<Future<Item = Option<bool>, Error = io::Error> + Send> {
         let channel_id = self.id;
 
         self.run_on_locked_transport_full("basic_publish", "Could not publish", |transport| {
@@ -295,7 +295,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     ///
     /// `Consumer` implements `futures::Stream`, so it can be used with any of
     /// the usual combinators
-    pub fn basic_consume(&self, queue: &str, consumer_tag: &str, options: &BasicConsumeOptions, arguments: &FieldTable) -> Box<Future<Item = Consumer<T>, Error = io::Error>> {
+    pub fn basic_consume(&self, queue: &str, consumer_tag: &str, options: &BasicConsumeOptions, arguments: &FieldTable) -> Box<Future<Item = Consumer<T>, Error = io::Error> + Send> {
         let consumer = Consumer {
             transport:    self.transport.clone(),
             channel_id:   self.id,
@@ -313,28 +313,28 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     }
 
     /// acks a message
-    pub fn basic_ack(&self, delivery_tag: u64) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn basic_ack(&self, delivery_tag: u64) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("basic_ack", "Could not ack message", |transport| {
             transport.conn.basic_ack(self.id, delivery_tag, false).map(|_| None)
         })
     }
 
     /// nacks a message
-    pub fn basic_nack(&self, delivery_tag: u64, requeue: bool) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn basic_nack(&self, delivery_tag: u64, requeue: bool) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("basic_nack", "Could not nack message", |transport| {
             transport.conn.basic_nack(self.id, delivery_tag, false, requeue).map(|_| None)
         })
     }
 
     /// rejects a message
-    pub fn basic_reject(&self, delivery_tag: u64, requeue: bool) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn basic_reject(&self, delivery_tag: u64, requeue: bool) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("basic_reject", "Could not reject message", |transport| {
             transport.conn.basic_reject(self.id, delivery_tag, requeue).map(|_| None)
         })
     }
 
     /// gets a message
-    pub fn basic_get(&self, queue: &str, options: &BasicGetOptions) -> Box<Future<Item = Message, Error = io::Error>> {
+    pub fn basic_get(&self, queue: &str, options: &BasicGetOptions) -> Box<Future<Item = Message, Error = io::Error> + Send> {
         let channel_id = self.id;
         let _queue = queue.to_string();
         let receive_transport = self.transport.clone();
@@ -369,7 +369,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// Purge a queue.
     ///
     /// This method removes all messages from a queue which are not awaiting acknowledgment.
-    pub fn queue_purge(&self, queue_name: &str, options: &QueuePurgeOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_purge(&self, queue_name: &str, options: &QueuePurgeOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("queue_purge", "Could not purge queue", |transport| {
             transport.conn.queue_purge(self.id, options.ticket, queue_name.to_string(), options.nowait).map(Some)
         })
@@ -384,22 +384,22 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     /// If the queue has consumers the server does not delete it but raises a channel exception instead.
     ///
     /// If `if_empty` is set, the server will only delete the queue if it has no messages.
-    pub fn queue_delete(&self, queue_name: &str, options: &QueueDeleteOptions) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn queue_delete(&self, queue_name: &str, options: &QueueDeleteOptions) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("queue_purge", "Could not purge queue", |transport| {
             transport.conn.queue_delete(self.id, options.ticket, queue_name.to_string(), options.if_unused, options.if_empty, options.no_wait).map(Some)
         })
     }
 
     /// closes the cannel
-    pub fn close(&self, code: u16, message: &str) -> Box<Future<Item = (), Error = io::Error>> {
+    pub fn close(&self, code: u16, message: &str) -> Box<Future<Item = (), Error = io::Error> + Send> {
         self.run_on_locked_transport("close", "Could not close channel", |transport| {
             transport.conn.channel_close(self.id, code, message.to_string(), 0, 0).map(|_| None)
         })
     }
 
-    fn run_on_locked_transport_full<Action, Finished>(&self, method: &str, error: &str, action: Action, finished: Finished, payload: Option<(u16, &[u8], BasicProperties)>) -> Box<Future<Item = Option<bool>, Error = io::Error>>
+    fn run_on_locked_transport_full<Action, Finished>(&self, method: &str, error: &str, action: Action, finished: Finished, payload: Option<(u16, &[u8], BasicProperties)>) -> Box<Future<Item = Option<bool>, Error = io::Error> + Send>
         where Action:   Fn(&mut AMQPTransport<T>) -> Result<Option<RequestId>, lapin_async::error::Error>,
-              Finished: 'static + Fn(&mut Connection, RequestId) -> Poll<Option<bool>, io::Error> {
+              Finished: 'static + Send + Fn(&mut Connection, RequestId) -> Poll<Option<bool>, io::Error> {
         if let Ok(mut transport) = self.transport.lock() {
             match action(&mut transport) {
                 Err(e)         => Box::new(future::err(Error::new(ErrorKind::Other, format!("{}: {:?}", error, e)))),
@@ -431,7 +431,7 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
         }
     }
 
-    fn run_on_locked_transport<Action>(&self, method: &str, error: &str, action: Action) -> Box<Future<Item = (), Error = io::Error>>
+    fn run_on_locked_transport<Action>(&self, method: &str, error: &str, action: Action) -> Box<Future<Item = (), Error = io::Error> + Send>
         where Action: Fn(&mut AMQPTransport<T>) -> Result<Option<RequestId>, lapin_async::error::Error> {
         Box::new(self.run_on_locked_transport_full(method, error, action, |conn, request_id| {
             match conn.is_finished(request_id) {
@@ -442,8 +442,8 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Channel<T> {
     }
 
     /// internal method to wait until a request succeeds
-    pub fn wait_for_answer<Finished>(transport: Arc<Mutex<AMQPTransport<T>>>, request_id: RequestId, finished: Finished) -> Box<Future<Item = Option<bool>, Error = io::Error>>
-        where Finished: 'static + Fn(&mut Connection, RequestId) -> Poll<Option<bool>, io::Error> {
+    pub fn wait_for_answer<Finished>(transport: Arc<Mutex<AMQPTransport<T>>>, request_id: RequestId, finished: Finished) -> Box<Future<Item = Option<bool>, Error = io::Error> + Send>
+        where Finished: 'static + Send + Fn(&mut Connection, RequestId) -> Poll<Option<bool>, io::Error> {
         trace!("wait for answer for request {}", request_id);
         Box::new(future::poll_fn(move || {
             if let Ok(mut tr) = transport.try_lock() {

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -115,7 +115,7 @@ impl<T> AMQPTransport<T>
   /// starts the connection process
   ///
   /// returns a future of a `AMQPTransport` that is connected
-  pub fn connect(stream: T, options: &ConnectionOptions) -> Box<Future<Item = AMQPTransport<T>, Error = io::Error>> {
+  pub fn connect(stream: T, options: &ConnectionOptions) -> Box<Future<Item = AMQPTransport<T>, Error = io::Error> + Send> {
     let mut conn = Connection::new();
     conn.set_credentials(&options.username, &options.password);
     conn.set_vhost(&options.vhost);


### PR DESCRIPTION
This allows the use of `lapin-future` with the newly introduced tokio
runtime.