### PR TITLE
Allow heartbeat task cancellation

### DIFF
--- a/futures/examples/client.rs
+++ b/futures/examples/client.rs
@@ -25,9 +25,8 @@ fn main() {
         frame_max: 65535,
         ..Default::default()
       })
-    }).and_then(|(client, heartbeat_future_fn)| {
-      let heartbeat_client = client.clone();
-      handle.spawn(heartbeat_future_fn(&heartbeat_client).map_err(|e| println!("{:?}", e)));
+    }).and_then(|(client, heartbeat)| {
+      handle.spawn(heartbeat.map_err(|e| println!("{:?}", e)));
 
       client.create_confirm_channel(ConfirmSelectOptions::default()).and_then(|channel| {
         let id = channel.id;

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -43,7 +43,7 @@
 //!       // connect() returns a future of an AMQP Client
 //!       // that resolves once the handshake is done
 //!       lapin::client::Client::connect(stream, &ConnectionOptions::default())
-//!    }).and_then(|(client, _ /* heartbeat_future_fn */)| {
+//!    }).and_then(|(client, _ /* heartbeat */)| {
 //!
 //!       // create_channel returns a future that is resolved
 //!       // once the channel is successfully created
@@ -95,13 +95,13 @@
 //!       // connect() returns a future of an AMQP Client
 //!       // that resolves once the handshake is done
 //!       lapin::client::Client::connect(stream, &ConnectionOptions::default())
-//!    }).and_then(|(client, heartbeat_future_fn)| {
+//!    }).and_then(|(client, heartbeat)| {
 //!      // The heartbeat future should be run in a dedicated thread so that nothing can prevent it from
 //!      // dispatching events on time.
 //!      // If we ran it as part of the "main" chain of futures, we might end up not sending
 //!      // some heartbeats if we don't poll often enough (because of some blocking task or such).
 //!      let heartbeat_client = client.clone();
-//!      handle.spawn(heartbeat_future_fn(&heartbeat_client).map_err(|_| ()));
+//!      handle.spawn(heartbeat.map_err(|_| ()));
 //!
 //!       // create_channel returns a future that is resolved
 //!       // once the channel is successfully created


### PR DESCRIPTION
The first commit of this PR fixes a nasty bug I encountered while migrating my library to the reformed tokio: some futures were dropped at what seemed be to random. After some investigation the root cause appeared to be that `poll_fn` were not notifying the current task to be rescheduled when returning `Ok(Async::NotReady)`. The patch reschedule the future for execution before returning `Ok(Async::NotReady)` making sure it will get executed again. I can extract it into its own PR if you prefer.

The second commit of this PR replace the `heartbeat_future_fn` callback with a `Heartbeat` structure that implements `Future` and a `HeartbeatHandle` for stopping the heartbeat. The `Heartbeat` `Future` encapsulates the timer behavior and sends a heartbeat to RabbitMQ as before but it also checks for a signal coming from `HeartbeatHandle` telling it to stop. This avoids leaking resources (such as timers or sockets) and makes it easier to integrate with the new tokio runtime.