### PR TITLE
Rewrite `AMQPTransport` to better fit the task model

### DIFF
--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -130,8 +130,8 @@ extern crate nom;
 extern crate tokio_io;
 extern crate tokio_timer;
 
-pub mod client;
 #[macro_use] pub mod transport;
+pub mod client;
 pub mod channel;
 pub mod consumer;
 pub mod message;


### PR DESCRIPTION
`AMQPTransport` is now a future that always return `Ok(Async::NotReady)`
and resolves once the connection is closed. Polling the transport does
two things: (a) it polls the socket for incoming frames from the broker,
and (b) it polls the socket and sends outcoming frames to the broker.
This is a lot like the old `send_and_handle_frames` method except that
now tasks are properly rescheduled when frames cannot be sent.

Fixes #96.