### PR TITLE
"impl Trait" in stable Rust just arrived

### DIFF
--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -207,35 +207,35 @@ impl<T: AsyncRead+AsyncWrite+Send+'static> Client<T> {
   /// );
   /// # }
   /// ```
-  pub fn connect(stream: T, options: ConnectionOptions) -> Box<Future<Item = (Self, Heartbeat), Error = io::Error> + Send> {
-    Box::new(AMQPTransport::connect(stream, options).and_then(|transport| {
+  pub fn connect(stream: T, options: ConnectionOptions) -> impl Future<Item = (Self, Heartbeat), Error = io::Error> + Send {
+    AMQPTransport::connect(stream, options).and_then(|transport| {
       debug!("got client service");
       let configuration = transport.conn.configuration.clone();
       let transport = Arc::new(Mutex::new(transport));
       let heartbeat = Heartbeat::new(transport.clone(), configuration.heartbeat);
       let client = Client { configuration, transport };
       Ok((client, heartbeat))
-    }))
+    })
   }
 
   /// creates a new channel
   ///
   /// returns a future that resolves to a `Channel` once the method succeeds
-  pub fn create_channel(&self) -> Box<Future<Item = Channel<T>, Error = io::Error> + Send> {
+  pub fn create_channel(&self) -> impl Future<Item = Channel<T>, Error = io::Error> + Send {
     Channel::create(self.transport.clone())
   }
 
   /// returns a future that resolves to a `Channel` once the method succeeds
   /// the channel will support RabbitMQ's confirm extension
-  pub fn create_confirm_channel(&self, options: ConfirmSelectOptions) -> Box<Future<Item = Channel<T>, Error = io::Error> + Send> {
+  pub fn create_confirm_channel(&self, options: ConfirmSelectOptions) -> impl Future<Item = Channel<T>, Error = io::Error> + Send {
 
     //FIXME: maybe the confirm channel should be a separate type
     //especially, if we implement transactions, the methods should be available on the original channel
     //but not on the confirm channel. And the basic publish method should have different results
-    Box::new(self.create_channel().and_then(move |channel| {
+    self.create_channel().and_then(move |channel| {
       let ch = channel.clone();
 
       channel.confirm_select(options).map(|_| ch)
-    }))
+    })
   }
 }

--- a/futures/src/transport.rs
+++ b/futures/src/transport.rs
@@ -116,14 +116,14 @@ impl<T> AMQPTransport<T>
   /// starts the connection process
   ///
   /// returns a future of a `AMQPTransport` that is connected
-  pub fn connect(stream: T, options: ConnectionOptions) -> Box<Future<Item = AMQPTransport<T>, Error = io::Error> + Send> {
+  pub fn connect(stream: T, options: ConnectionOptions) -> impl Future<Item = AMQPTransport<T>, Error = io::Error> + Send {
     let mut conn = Connection::new();
     conn.set_credentials(&options.username, &options.password);
     conn.set_vhost(&options.vhost);
     conn.set_frame_max(options.frame_max);
     conn.set_heartbeat(options.heartbeat);
 
-    Box::new(future::result(conn.connect()).map_err(|e| {
+    future::result(conn.connect()).map_err(|e| {
       let err = format!("Failed to connect: {:?}", e);
       Error::new(ErrorKind::ConnectionAborted, err)
     }).and_then(|_| {
@@ -139,7 +139,7 @@ impl<T> AMQPTransport<T>
         AMQPTransportConnector {
           transport: Some(t),
         }
-    }))
+    })
   }
 
   /// Send a frame to the broker.


### PR DESCRIPTION
[impl Trait](https://blog.rust-lang.org/2018/05/10/Rust-1.26.html) has finally out in recent stable 1.26, so we could get rid of all `Box`-es in our code.  

In theory this means less alloc/free, no vtable method calls, aggressive compiler inlining and optimization abilities, etc :)