### PR TITLE
Allow disabling heartbeat

### DIFF
--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -64,42 +64,50 @@ impl Heartbeat {
     {
         use self::future::{loop_fn, Either, Loop};
         let (tx, rx) = oneshot::channel();
-        let interval = Interval::new(Instant::now(), Duration::from_secs(heartbeat.into()))
-            .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
-            .into_future();
-        let neverending = loop_fn((interval, rx), move |(f, rx)| {
-            let transport_send = Arc::clone(&transport);
-            let transport = Arc::clone(&transport);
-            let heartbeat = f.and_then(move |(_instant, interval)| {
-                debug!("poll heartbeat");
-                future::poll_fn(move || {
-                    let mut transport = try_lock_transport!(transport_send);
-                    debug!("Sending heartbeat");
-                    transport.send_frame(Frame::Heartbeat(0));
-                    Ok(Async::Ready(()))
-                }).and_then(move |_| future::poll_fn(move || {
-                    let mut transport = try_lock_transport!(transport);
-                    transport.poll_send()
-                })).then(move |r| match r {
-                    Ok(_) => Ok(interval),
-                    Err(cause) => Err((cause, interval)),
+        debug!("heartbeat; interval={}", heartbeat);
+        let neverending: Box<Future<Item = (), Error = io::Error> + Send> = if heartbeat == 0 {
+            Box::new(
+              rx.then(|_| Ok(()))
+            )
+        } else {
+            let interval = Interval::new(Instant::now(), Duration::from_secs(heartbeat.into()))
+                .map_err(|err| io::Error::new(io::ErrorKind::Other, err))
+                .into_future();
+            let f = loop_fn((interval, rx), move |(f, rx)| {
+                let transport_send = Arc::clone(&transport);
+                let transport = Arc::clone(&transport);
+                let heartbeat = f.and_then(move |(_instant, interval)| {
+                    debug!("poll heartbeat");
+                    future::poll_fn(move || {
+                        let mut transport = try_lock_transport!(transport_send);
+                        debug!("Sending heartbeat");
+                        transport.send_frame(Frame::Heartbeat(0));
+                        Ok(Async::Ready(()))
+                    }).and_then(move |_| future::poll_fn(move || {
+                        let mut transport = try_lock_transport!(transport);
+                        transport.poll_send()
+                    })).then(move |r| match r {
+                        Ok(_) => Ok(interval),
+                        Err(cause) => Err((cause, interval)),
+                    })
+                }).or_else(|(err, _interval)| {
+                    error!("Error occured in heartbeat interval: {}", err);
+                    Err(err)
+                });
+                heartbeat.select2(rx).then(|res| {
+                    match res {
+                        Ok(Either::A((interval, rx))) => Ok(Loop::Continue((interval.into_future(), rx))),
+                        Ok(Either::B((_rx, _interval))) => Ok(Loop::Break(())),
+                        Err(Either::A((err, _rx))) => Err(io::Error::new(io::ErrorKind::Other, err)),
+                        Err(Either::B((err, _interval))) => Err(io::Error::new(io::ErrorKind::Other, err)),
+                    }
                 })
-            }).or_else(|(err, _interval)| {
-                error!("Error occured in heartbeat interval: {}", err);
-                Err(err)
             });
-            heartbeat.select2(rx).then(|res| {
-                match res {
-                    Ok(Either::A((interval, rx))) => Ok(Loop::Continue((interval.into_future(), rx))),
-                    Ok(Either::B((_rx, _interval))) => Ok(Loop::Break(())),
-                    Err(Either::A((err, _rx))) => Err(io::Error::new(io::ErrorKind::Other, err)),
-                    Err(Either::B((err, _interval))) => Err(io::Error::new(io::ErrorKind::Other, err)),
-                }
-            })
-        });
+            Box::new(f)
+        };
         Heartbeat {
             handle: Some(HeartbeatHandle(tx)),
-            pulse: Box::new(neverending),
+            pulse: neverending,
         }
     }
 


### PR DESCRIPTION
This fixes two bugs:
* when the broker sends a heartbeat interval of 0 it means the client
  shouldn't send any heartbeat frames
* tokio's timer panics if the duration between each interval is 0