### PR TITLE
Refactor AMQPCodec

### DIFF
--- a/async/Cargo.toml
+++ b/async/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 log = "^0.4"
 nom = "^3.0"
-cookie-factory = "^0.2"
+cookie-factory = "^0.2.4"
 amq-protocol = "^0.19"
 
 [dependencies.sasl]

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -123,7 +123,7 @@
 
 extern crate cookie_factory;
 extern crate bytes;
-#[macro_use] extern crate futures;
+extern crate futures;
 extern crate lapin_async;
 #[macro_use] extern crate log;
 extern crate nom;


### PR DESCRIPTION
> ~~**BLOCKED**: this PR needs a fix that only recently landed on cookie-factory's master branch (see Geal/cookie-factory#9).~~

The `AMQPCodec::encode` function overwrote the contents of the buffer
given to it, forcing its users to flush the buffer after encoding each
item.

The new implementation simplifies `AMQPTransport` and especially allows
for the removal of the `flush_needed` attribute.