### PR TITLE
Add a convenience method for parsing AMQP URI

### DIFF
--- a/futures/Cargo.toml
+++ b/futures/Cargo.toml
@@ -19,6 +19,7 @@ tokio-io = "^0.1"
 tokio-timer = "^0.2"
 lapin-async = {version = "^0.11", path = "../async"}
 cookie-factory = "^0.2"
+amq-protocol = "^0.19"
 
 [dev-dependencies]
 nom = "^3.0"

--- a/futures/src/lib.rs
+++ b/futures/src/lib.rs
@@ -121,6 +121,7 @@
 //! ```
 //!
 
+extern crate amq_protocol;
 extern crate cookie_factory;
 extern crate bytes;
 extern crate futures;


### PR DESCRIPTION
Not sure if there's already a way to do this, but I have to roll this by hand in my application. It would be nice if it were defined straight on the struct?