### PR TITLE
Replace future::empty with future::ok in heartbeat pulse future

### DIFF
--- a/futures/src/client.rs
+++ b/futures/src/client.rs
@@ -82,7 +82,7 @@ fn heartbeat_pulse<T: AsyncRead+AsyncWrite+Send+'static>(transport: Arc<Mutex<AM
     };
 
     future::select_all(vec![
-        future::Either::A(rx.map(|_| debug!("Stopping heartbeat")).or_else(|_| future::empty())),
+        future::Either::A(rx.map(|_| debug!("Stopping heartbeat")).or_else(|_| future::ok(()))),
         future::Either::B(future::result(interval).or_else(|_| future::empty()).and_then(move |interval| {
             interval.for_each(move |_| {
                 debug!("poll heartbeat");


### PR DESCRIPTION
Using future::empty means that this task will never finish, preventing
the runtime executing from stopping. Instead, it is now using future::ok
which will immediately return.