### PR TITLE
Fix #157

### DIFF
--- a/async/src/api.rs
+++ b/async/src/api.rs
@@ -1619,7 +1619,7 @@ impl Connection {
         }
 
         match self.get_next_answer(_channel_id) {
-          Some(Answer::AwaitingPublishConfirm(request_id)) => {
+          Some(Answer::AwaitingPublishConfirm(_request_id)) => {
             self.channels.get_mut(&_channel_id).map(|c| {
               if c.confirm {
                 if method.multiple {
@@ -1635,8 +1635,6 @@ impl Connection {
                 }
               }
             });
-
-            self.finished_reqs.insert(request_id, true);
 
             Ok(())
           },
@@ -1661,7 +1659,7 @@ impl Connection {
         }
 
         match self.get_next_answer(_channel_id) {
-          Some(Answer::AwaitingPublishConfirm(request_id)) => {
+          Some(Answer::AwaitingPublishConfirm(_request_id)) => {
             self.channels.get_mut(&_channel_id).map(|c| {
               if c.confirm {
                 if method.multiple {
@@ -1677,8 +1675,6 @@ impl Connection {
                 }
               }
             });
-
-            self.finished_reqs.insert(request_id, true);
 
             Ok(())
           },


### PR DESCRIPTION
We don't use finished_reqs in case of basic_publish, as it is the role of channel.acked/unacked/nacked