### PR TITLE
implemented Fail by hand to remove dependency on failure_derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ version = "=0.3.0-alpha.16"
 optional = true
 
 [dependencies]
-failure = "^0.1"
+failure = { version = "^0.1", default-features = false, features = ["std"] }
 log = "^0.4"
 mio = "^0.6"
 parking_lot = '^0.8'


### PR DESCRIPTION
I'm doing some work with ARM/musl targets at the moment, and proc_macro crates don't seem to work when cross-compiling for ARM/musl. This means that crates like failure_derive can't be used.

Since lapin was my only dependency that depended on a proc_macro (failure_derive), I removed the dependency by implementing `Fail` for `ErrorKind` directly rather than using derive. There should be no behaviour change from this, it just removes one dependency from the tree.

I understand if you don't want to merge this as it's a workaround for a pretty specific issue, but in case you do, here it is :)