### PR TITLE
Broadcast connection errors to wait handles

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -242,6 +242,7 @@ impl Connection {
     error!("Connection error");
     self.set_state(ConnectionState::Error);
     self.channels.set_error()?;
+    self.frames.clear_with_error();
     self.error_handler.on_error();
     Ok(())
   }

--- a/src/frames.rs
+++ b/src/frames.rs
@@ -11,6 +11,7 @@ use crate::{
   channel::Reply,
   id_sequence::IdSequence,
   wait::{Wait, WaitHandle},
+  error::{Error, ErrorKind},
 };
 
 pub(crate) type SendId = u64;
@@ -62,6 +63,12 @@ impl Frames {
 
   pub(crate) fn drop_pending(&self) {
     self.inner.lock().drop_pending();
+  }
+
+  pub(crate) fn clear_with_error(&self) {
+    for (_, wait_handle) in self.inner.lock().outbox.drain() {
+      wait_handle.error(Error::from(ErrorKind::IoLoopError));
+    }
   }
 }
 


### PR DESCRIPTION
On a connection error (e.g. connection reset), all the threads/tasks using `.wait()`/`.await` on a `Wait<>` should get awoken with an error (instead of continuing to sleep forever).

The only complication here is that it's impossible to actually send an error to each one since `Error` does not impl `Clone` (in part because `io::Error` does not). So instead send them a generic `IoLoopError`.