### PR TITLE
make PublisherConfirm return a Result<Confirmation>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Breaking changes
 
 * Update to pinky-swear 3.0.0 (properly handle chaining result promises)
+* `Confirmation` can no longer hold an error
+* `PublisherConfirm` now returns a proper `Result<Confirmation>`
 
 #### Features
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ This project follows the [AMQP 0.9.1 specifications](https://www.rabbitmq.com/re
 use futures_executor::LocalPool;
 use futures_util::{future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 use lapin::{
-    options::*, types::FieldTable, BasicProperties, Connection, ConnectionProperties, Result,
+    options::*, publisher_confirm::Confirmation, types::FieldTable, BasicProperties, Connection,
+    ConnectionProperties, Result,
 };
 use log::info;
 
@@ -85,7 +86,7 @@ fn main() -> Result<()> {
         let payload = b"Hello world!";
 
         loop {
-            channel_a
+            let confirm = channel_a
                 .basic_publish(
                     "",
                     "hello",
@@ -93,7 +94,9 @@ fn main() -> Result<()> {
                     payload.to_vec(),
                     BasicProperties::default(),
                 )
+                .await?
                 .await?;
+            assert_eq!(confirm, Confirmation::NotRequested);
         }
     })
 }

--- a/examples/close_on_drop.rs
+++ b/examples/close_on_drop.rs
@@ -69,7 +69,8 @@ fn main() {
             )
             .await
             .expect("basic_publish")
-            .await;
+            .await
+            .expect("publisher-confirms");
         assert_eq!(confirm, Confirmation::NotRequested);
 
         std::thread::sleep(std::time::Duration::from_millis(2000));

--- a/examples/connection.rs
+++ b/examples/connection.rs
@@ -71,7 +71,8 @@ fn main() {
             )
             .await
             .expect("basic_publish")
-            .await;
+            .await
+            .expect("publisher-confirms");
         assert_eq!(confirm, Confirmation::NotRequested);
         info!("[{}] state: {:?}", line!(), conn.status().state());
 

--- a/examples/custom_tls_connection.rs
+++ b/examples/custom_tls_connection.rs
@@ -95,7 +95,8 @@ fn main() {
             )
             .await
             .expect("basic_publish")
-            .await;
+            .await
+            .expect("publisher-confirms");
         assert_eq!(confirm, Confirmation::NotRequested);
         info!("[{}] state: {:?}", line!(), conn.status().state());
     })

--- a/examples/publisher_confirms.rs
+++ b/examples/publisher_confirms.rs
@@ -78,7 +78,8 @@ fn main() {
             )
             .await
             .expect("basic_publish")
-            .await; // Wait for this specific ack/nack
+            .await // Wait for this specific ack/nack
+            .expect("publisher-confirms");
         assert_eq!(confirm, Confirmation::Ack);
         info!("[{}] state: {:?}", line!(), conn.status().state());
 

--- a/examples/pubsub.rs
+++ b/examples/pubsub.rs
@@ -64,7 +64,7 @@ fn main() -> Result<()> {
                     BasicProperties::default(),
                 )
                 .await?
-                .await;
+                .await?;
             assert_eq!(confirm, Confirmation::NotRequested);
         }
     })

--- a/examples/pubsub_nofutures.rs
+++ b/examples/pubsub_nofutures.rs
@@ -70,7 +70,8 @@ fn main() {
             )
             .wait()
             .expect("basic_publish")
-            .wait();
+            .wait()
+            .expect("publisher-confirms");
         assert_eq!(confirm, Confirmation::NotRequested);
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -110,7 +110,9 @@ impl Channel {
         self.do_exchange_declare(exchange, kind.kind(), options, arguments)
     }
 
-    pub fn wait_for_confirms(&self) -> PinkySwear<Result<Vec<BasicReturnMessage>>, Confirmation> {
+    pub fn wait_for_confirms(
+        &self,
+    ) -> PinkySwear<Result<Vec<BasicReturnMessage>>, Result<Confirmation>> {
         if let Some(promise) = self.acknowledgements.get_last_pending() {
             trace!("Waiting for pending confirms");
             let returned_messages = self.returned_messages.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,8 @@
 //! use futures_executor::LocalPool;
 //! use futures_util::{future::FutureExt, stream::StreamExt, task::LocalSpawnExt};
 //! use lapin::{
-//!     options::*, types::FieldTable, BasicProperties, Connection, ConnectionProperties, Result,
+//!     options::*, publisher_confirm::Confirmation, types::FieldTable, BasicProperties, Connection,
+//!     ConnectionProperties, Result,
 //! };
 //! use log::info;
 //!
@@ -71,7 +72,7 @@
 //!         let payload = b"Hello world!";
 //!
 //!         loop {
-//!             channel_a
+//!             let confirm = channel_a
 //!                 .basic_publish(
 //!                     "",
 //!                     "hello",
@@ -79,7 +80,9 @@
 //!                     payload.to_vec(),
 //!                     BasicProperties::default(),
 //!                 )
+//!                 .await?
 //!                 .await?;
+//!             assert_eq!(confirm, Confirmation::NotRequested);
 //!         }
 //!     })
 //! }

--- a/tests/connection.rs
+++ b/tests/connection.rs
@@ -97,7 +97,8 @@ fn connection() {
         )
         .wait()
         .expect("basic_publish")
-        .wait();
+        .wait()
+        .expect("publisher-confirms");
     assert_eq!(confirm, Confirmation::NotRequested);
     println!("[{}] state: {:?}", line!(), conn.status().state());
 


### PR DESCRIPTION
Instead of having Error as part of the Confirmation enum

I think it's the right thing to do, still weighing the cons